### PR TITLE
Misspelling in optional attribute (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bottomNavigationBar: FancyBottomNavigation(
 **circleColor** -> Defaults to null, derives from `Theme`<br/>
 **activeIconColor** -> Defaults to null, derives from `Theme`<br/>
 **inactiveIconColor** -> Defaults to null, derives from `Theme`<br/>
-**taxtColor** -> Defaults to null, derives from `Theme`<br/>
+**textColor** -> Defaults to null, derives from `Theme`<br/>
 **barBackgroundColor** -> Defaults to null, derives from `Theme`<br/>
 **key** -> Defaults to null<br/>
 


### PR DESCRIPTION
taxtColor was modified to textColor

Misspelling in:

https://github.com/tunitowen/fancy_bottom_navigation/blob/9356611151de494023357895eecc8a66acefd909/README.md#L51

This was modified to:

https://github.com/tunitowen/fancy_bottom_navigation/blob/166ca87592385ce7b7e447f97becbab0b1a46550/README.md#L51
