### PR TITLE
Issue 58

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
         ],
         initialSelection: 1,
         key: bottomNavigationKey,
+        fontSize: 18,
         onTabChangedListener: (position) {
           setState(() {
             currentPage = position;

--- a/lib/fancy_bottom_navigation.dart
+++ b/lib/fancy_bottom_navigation.dart
@@ -22,6 +22,7 @@ class FancyBottomNavigation extends StatefulWidget {
       this.activeIconColor,
       this.inactiveIconColor,
       this.textColor,
+      this.fontSize,
       this.barBackgroundColor})
       : assert(onTabChangedListener != null),
         assert(tabs != null),
@@ -32,6 +33,7 @@ class FancyBottomNavigation extends StatefulWidget {
   final Color? activeIconColor;
   final Color? inactiveIconColor;
   final Color? textColor;
+  final double? fontSize;
   final Color? barBackgroundColor;
   final List<TabData> tabs;
   final int initialSelection;
@@ -56,6 +58,7 @@ class FancyBottomNavigationState extends State<FancyBottomNavigation>
   late Color inactiveIconColor;
   late Color barBackgroundColor;
   late Color textColor;
+  late double fontSize;
 
   @override
   void didChangeDependencies() {
@@ -81,6 +84,7 @@ class FancyBottomNavigationState extends State<FancyBottomNavigation>
         ((Theme.of(context).brightness == Brightness.dark)
             ? Colors.white
             : Colors.black54);
+    fontSize = widget.fontSize ?? 12;
     inactiveIconColor = (widget.inactiveIconColor) ??
         ((Theme.of(context).brightness == Brightness.dark)
             ? Colors.white
@@ -128,6 +132,7 @@ class FancyBottomNavigationState extends State<FancyBottomNavigation>
                     title: t.title,
                     iconColor: inactiveIconColor,
                     textColor: textColor,
+                    fontSize: fontSize,
                     callbackFunction: (uniqueKey) {
                       int selected = widget.tabs
                           .indexWhere((tabData) => tabData.key == uniqueKey);

--- a/lib/internal/tab_item.dart
+++ b/lib/internal/tab_item.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 const double ICON_OFF = -3;
 const double ICON_ON = 0;
-const double TEXT_OFF = 3;
 const double TEXT_ON = 1;
 const double ALPHA_OFF = 0;
 const double ALPHA_ON = 1;
@@ -29,7 +28,6 @@ class TabItem extends StatelessWidget {
   final double fontSize;
 
   final double iconYAlign = ICON_ON;
-  final double textYAlign = TEXT_OFF;
   final double iconAlpha = ALPHA_ON;
 
   @override
@@ -43,7 +41,7 @@ class TabItem extends StatelessWidget {
             width: double.infinity,
             child: AnimatedAlign(
                 duration: Duration(milliseconds: ANIM_DURATION),
-                alignment: Alignment(0, (selected) ? TEXT_ON : TEXT_OFF),
+                alignment: Alignment(0, (selected) ? TEXT_ON : 1 + fontSize / 2),
                 child: Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: Text(

--- a/lib/internal/tab_item.dart
+++ b/lib/internal/tab_item.dart
@@ -16,7 +16,8 @@ class TabItem extends StatelessWidget {
       required this.title,
       required this.callbackFunction,
       required this.textColor,
-      required this.iconColor});
+      required this.iconColor,
+      required this.fontSize});
 
   final UniqueKey uniqueKey;
   final String title;
@@ -25,6 +26,7 @@ class TabItem extends StatelessWidget {
   final Function(UniqueKey uniqueKey) callbackFunction;
   final Color textColor;
   final Color iconColor;
+  final double fontSize;
 
   final double iconYAlign = ICON_ON;
   final double textYAlign = TEXT_OFF;
@@ -49,7 +51,8 @@ class TabItem extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                     maxLines: 1,
                     style: TextStyle(
-                        fontWeight: FontWeight.w600, color: textColor),
+                        fontWeight: FontWeight.w600, color: textColor,
+                    fontSize: fontSize),
                   ),
                 )),
           ),


### PR DESCRIPTION
I've added `fontSize` field to `TabItem` class and that determines the size of `TabData` titles. If you leave it null, it will be 12. 

I deleted `const double TEXT_OFF = 3;`, because there was an issue with titles of the tabs that were off and changed that into `1 + fontSize / 2`

In the example I put it 18 and you can see it here:

![image_2021-07-15_161314](https://user-images.githubusercontent.com/59291771/125782573-92c23c87-1b76-48a0-a8fe-25e3c2d0b39a.png)

can close issue #58 